### PR TITLE
구글연동 유저 연동버튼 비활성화, 이름 변경 모달창 에러 수정

### DIFF
--- a/web/src/app/(Layout)/components/DashboardCompo.tsx
+++ b/web/src/app/(Layout)/components/DashboardCompo.tsx
@@ -17,6 +17,7 @@ export default function DashboardCompo() {
   const [submittedDocuments, setSubmittedDocuments] = useState<
     SubmittedDocument[]
   >([]);
+  const [isLink, setIsLink] = useState<boolean>(false);
   const customFetch = useCustomFetch();
   const [language, setLanguage] = useState<Language>(Language.korean);
   const [menuOpen, setMenuOpen] = useState<{ [key: number]: boolean }>({});
@@ -41,7 +42,6 @@ export default function DashboardCompo() {
         });
 
         if (response && response.data) {
-          console.log(response.data)
           setSubmittedDocuments(response.data);
         }
       }
@@ -49,6 +49,16 @@ export default function DashboardCompo() {
       fetchSubmittedDocuments();
     }
   }, [user]); // user가 변경될 때마다 실행되도록
+
+  useEffect(()=>{
+    async function userCheck() {
+      const response = await customFetch("/users/info", {
+        method: "GET",
+      })
+      setIsLink(response.isLinked)
+    }
+    userCheck()
+  },[])
 
   const toggleMenu = (id: number) => {
     setMenuOpen((prev) => ({
@@ -92,12 +102,15 @@ export default function DashboardCompo() {
             >
               {DashboardCompoMenu[language].nameChange}
             </button>
+            
+            {!isLink ? 
             <button
               onClick={() => googleConnectHandle()}
               className="px-4 py-2 bg-blue-500 text-white rounded-md hover:bg-blue-600 transition duration-300 text-center"
             >
               {DashboardCompoMenu[language].connectGoogle}
-            </button>
+            </button> 
+            : null}
           </div>
         </div>
 

--- a/web/src/app/(Layout)/components/NameChangeModal.tsx
+++ b/web/src/app/(Layout)/components/NameChangeModal.tsx
@@ -42,7 +42,7 @@ export default function NameChangeModal({ isOpen, onClose }: NameChangeModalProp
   };
 
   return (
-    <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50">
+    <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-50">
       <div className="bg-white p-6 rounded-lg shadow-lg w-96">
         <h2 className="text-lg font-semibold mb-4">{NameChangeModalMenu[language].nameChange}</h2>
         <input


### PR DESCRIPTION
## 🔍 이 PR로 해결하고자 하는 문제는 무엇인가요?

구글연동 유저 연동버튼 비활성화, 이름 변경 모달창 에러 수정

## ✨ 이 PR로 주요하게 바뀐 점은 무엇인가요?

> 문제를 해결하면서 주요 변경 사항을 작성해주세요.

- 구글 연동된 유저로 로그인 시, 구글 연동버튼 비활성화
- 푸터가 이름변경 모달창 위로 오고, 가리는 현상 수정

## 🔖 주요 변경 사항 외에 추가로 변경된 부분이 있나요?

> 없으면 "없음"이라고 작성해주세요.

- 없음


## 📚 관련된 Issue나 Notion, 문서

> 이 PR이 해결하려는 문제와 관련된 Issue나 문서, Notion이 있다면 링크를 작성해주세요. Notion의 경우 [제목](링크) 형식으로 첨부해주세요.

- #87 

## 🖥 작동하는 모습

> 스크린샷이나 녹화된 비디오, 또는 gif를 추가해서, 리뷰어가 변경점을 이해하는 데 도움이 되도록 해주세요.

![image](https://github.com/user-attachments/assets/68058dc3-0686-4ca8-8a97-7ce5ce1f61b0)

